### PR TITLE
Try adding GitHub actions back now that script can run in headless mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-screenshots
-        path: whatsuphere.png
+        path: *.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-screenshots
-        path: *.png
+        path: /*.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Install ChromeDriver
+      run: |
+        CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1) \
+          && CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) \
+          && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
+          && cd /tmp \
+          && unzip chromedriver_linux64.zip \
+          && rm -rf chromedriver_linux64.zip \
+          && sudo mv chromedriver /usr/local/bin/chromedriver \
+          && sudo chmod +x /usr/local/bin/chromedriver \
+          && chromedriver --version --no-sandbox --headless
+    - name: Run tests
+      run: bundle exec ./bin/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,8 @@ jobs:
           && chromedriver --version --no-sandbox --headless
     - name: Run tests
       run: bundle exec ./bin/test
+    - name: Archive test screenshots
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-screenshots
+        path: whatsuphere.png

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Once you have completed the install steps above, you can simply run `./bin/run` 
 
 If the script fails partway through, you can look at the `./tmp/log.txt` file to see what the last successfully scraped URL was. Attempt to run the script again, pasting in the remaining URLs. If the failure persists, the script may have to be modified before proceeding.
 
+The script has been updated to run in headless mode, but if you want to still watch the browser you can run it with `SHOW_BROWSER=true ./bin/run`.
+
 ### Cleanup
 After you have saved or otherwise captured the exported data, you can use the `./bin/clean` script to remove the generated CSV files and logs between script runs.
 

--- a/bin/install
+++ b/bin/install
@@ -27,6 +27,7 @@ fi
 
 if ls -la .git >/dev/null 2>&1; then
   echo "Pulling the latest code..."
+  git checkout main
   git pull -q
 fi
 

--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./bin/install

--- a/lib/models/scraper.rb
+++ b/lib/models/scraper.rb
@@ -35,7 +35,8 @@ class Scraper
           author: book_element_text[1]
         )
       end
-      next_page_button.click
+      # if there's only one page of books, there won't be an actionable next page button
+      next_page_button.click unless carousel_pages == 1
       # === Execute CLI tracking block or callback after each page is done ===
       yield if block_given?
       # === Allow JS to load for next carousel page ===
@@ -53,8 +54,9 @@ class Scraper
   def start_driver
     raise "book_page_url is required" if book_page_url.empty?
     service = Selenium::WebDriver::Service.chrome(path: chromedriver_path)
-    driver_options = Selenium::WebDriver::Chrome::Options.new(binary: chromedriver_path)
-    @driver = Selenium::WebDriver.for(:chrome, service: service)
+    driver_args = ENV["SHOW_BROWSER"] == "true" ? [] : ["--headless"]
+    options = Selenium::WebDriver::Chrome::Options.new(args: driver_args)
+    @driver = Selenium::WebDriver.for(:chrome, service: service, options: options)
     driver.manage.window.resize_to(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.manage.timeouts.implicit_wait = DOM_WAIT_TIMEOUT_SECONDS
     driver.get(book_page_url)
@@ -89,6 +91,8 @@ class Scraper
     @carousel_verb = carousel_header_parent.text.split("\n").first.split.last
     @next_page_button = carousel_header_parent.find_element(:css, ".a-carousel-goto-nextpage")
     @carousel_pages = carousel_header_parent.find_element(:xpath, ".//*[@class='a-carousel-page-max']").text.to_i
+    # If there's no carousel pages count, it's likely because there's only one page
+    @carousel_pages = 1 if @carousel_pages.zero?
     @books_per_carousel_page = carousel_header_parent.find_elements(:xpath, ".//*[@class='a-carousel-card']").count
   end
 

--- a/lib/models/scraper.rb
+++ b/lib/models/scraper.rb
@@ -66,7 +66,7 @@ class Scraper
       begin
         driver.find_element(:css, "#sp-cc-accept").click
       rescue Selenium::WebDriver::Error::NoSuchElementError
-        driver.save_screenshot("whatsuphere.png")
+        driver.save_screenshot("missing_cookies_button_#{(Time.now.to_f * 1000).to_i}.png")
         # guess we don't need to accept cookies!
       end
     end

--- a/lib/models/scraper.rb
+++ b/lib/models/scraper.rb
@@ -62,8 +62,12 @@ class Scraper
     driver.get(book_page_url)
 
     if book_page_url.include?("www.amazon.co.uk")
-      # === Accept cookies in the UK ===
-      driver.find_element(:css, "#sp-cc-accept").click
+      # === Accept cookies in the UK, if asked ===
+      begin
+        driver.find_element(:css, "#sp-cc-accept").click
+      rescue Selenium::WebDriver::Error::NoSuchElementError
+        # guess we don't need to accept cookies!
+      end
     end
 
     # === NOTE ABOUT UI VERSIONS: ===

--- a/lib/models/scraper.rb
+++ b/lib/models/scraper.rb
@@ -66,6 +66,7 @@ class Scraper
       begin
         driver.find_element(:css, "#sp-cc-accept").click
       rescue Selenium::WebDriver::Error::NoSuchElementError
+        driver.save_screenshot("whatsuphere.png")
         # guess we don't need to accept cookies!
       end
     end

--- a/test/models/scraper_test.rb
+++ b/test/models/scraper_test.rb
@@ -35,8 +35,8 @@ class ScraperTest < Test::Unit::TestCase
   end
 
   def test_successfully_finds_books_in_canada
-    scraper = Scraper.new(book_page_url: "https://www.amazon.ca/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_1?dchild=1&keywords=seeing+jesus&qid=1627944583&sr=8-1")
+    scraper = Scraper.new(book_page_url: "https://www.amazon.ca/Sharing-Jesus-Seeing-Book-ebook/dp/B01E0EP1YG")
     scraper.run
-    assert scraper.books_found.count > 4
+    assert scraper.books_found.count > 10
   end
 end

--- a/test/models/scraper_test.rb
+++ b/test/models/scraper_test.rb
@@ -22,11 +22,11 @@ class ScraperTest < Test::Unit::TestCase
     assert scraper.books_found.count > 10
   end
 
-  # def test_successfully_finds_books_in_the_uk
-  #   scraper = Scraper.new(book_page_url: "https://www.amazon.co.uk/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_1?dchild=1&keywords=seeing+jesus&qid=1627944060&sr=8-1")
-  #   scraper.run
-  #   assert scraper.books_found.count > 10
-  # end
+  def test_successfully_finds_books_in_the_uk
+    scraper = Scraper.new(book_page_url: "https://www.amazon.co.uk/Sharing-Jesus-Seeing-Book-ebook/dp/B01E0EP1YG")
+    scraper.run
+    assert scraper.books_found.count > 10
+  end
 
   def test_successfully_finds_books_in_australia
     scraper = Scraper.new(book_page_url: "https://www.amazon.com.au/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_2?dchild=1&keywords=seeing+jesus&qid=1627944663&sr=8-2")

--- a/test/models/scraper_test.rb
+++ b/test/models/scraper_test.rb
@@ -37,6 +37,6 @@ class ScraperTest < Test::Unit::TestCase
   def test_successfully_finds_books_in_canada
     scraper = Scraper.new(book_page_url: "https://www.amazon.ca/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_1?dchild=1&keywords=seeing+jesus&qid=1627944583&sr=8-1")
     scraper.run
-    assert scraper.books_found.count > 10
+    assert scraper.books_found.count > 4
   end
 end

--- a/test/models/scraper_test.rb
+++ b/test/models/scraper_test.rb
@@ -22,11 +22,11 @@ class ScraperTest < Test::Unit::TestCase
     assert scraper.books_found.count > 10
   end
 
-  def test_successfully_finds_books_in_the_uk
-    scraper = Scraper.new(book_page_url: "https://www.amazon.co.uk/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_1?dchild=1&keywords=seeing+jesus&qid=1627944060&sr=8-1")
-    scraper.run
-    assert scraper.books_found.count > 10
-  end
+  # def test_successfully_finds_books_in_the_uk
+  #   scraper = Scraper.new(book_page_url: "https://www.amazon.co.uk/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_1?dchild=1&keywords=seeing+jesus&qid=1627944060&sr=8-1")
+  #   scraper.run
+  #   assert scraper.books_found.count > 10
+  # end
 
   def test_successfully_finds_books_in_australia
     scraper = Scraper.new(book_page_url: "https://www.amazon.com.au/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_2?dchild=1&keywords=seeing+jesus&qid=1627944663&sr=8-2")


### PR DESCRIPTION
### Description:
I attempted to add GitHub actions to run CI for this script but had trouble getting `chromedriver` working. In this second attempt, I've modified the script to run the scraper in headless mode by default to see if this can get me one step closer.

Along the way I found a new UI coming up when there were 5 or less books being suggested and adjusted the script to expect this. I found some weird CI errors in the UK where the cookie button couldn't be found, so I'm also attempting to capture screenshots in CI when that happens.

### Testing:
Test suite should all still pass