### PR TITLE
CI Troubleshooting round 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,13 @@ jobs:
   build:
 
     runs-on: macos-10.15
-    strategy:
-      matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: '2.7.2'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Install ChromeDriver
       run: |

--- a/lib/models/scraper.rb
+++ b/lib/models/scraper.rb
@@ -81,12 +81,7 @@ class Scraper
     customers_who_bought_this_book_parent = "//*[text()='Customers who bought this item also bought']/../../.."
     customers_who_read_this_book_parent = "//*[text()='Customers who read this book also read']/../../.."
     customers_who_viewed_this_item_parent = "//*[text()='Customers who viewed this item also viewed']/../../.."
-    begin
-      carousel_header_parent = driver.find_element(:xpath, "#{customers_who_bought_this_book_parent} | #{customers_who_read_this_book_parent} | #{customers_who_viewed_this_item_parent}")
-    rescue Selenium::WebDriver::Error::NoSuchElementError => e
-      driver.save_screenshot("missing_carousel_header_parent_#{(Time.now.to_f * 1000).to_i}.png")
-      raise e
-    end
+    carousel_header_parent = driver.find_element(:xpath, "#{customers_who_bought_this_book_parent} | #{customers_who_read_this_book_parent} | #{customers_who_viewed_this_item_parent}")
 
     # === Navigate down to the carousel in the browser to trigger the JS to load ===
     customers_who_bought_this_book_header = "//*[text()='Customers who bought this item also bought']"
@@ -104,6 +99,9 @@ class Scraper
     # If there's no carousel pages count, it's likely because there's only one page
     @carousel_pages = 1 if @carousel_pages.zero?
     @books_per_carousel_page = carousel_header_parent.find_elements(:xpath, ".//*[@class='a-carousel-card']").count
+  rescue Selenium::WebDriver::Error::NoSuchElementError => e
+    driver.save_screenshot("missing_dom_element_#{(Time.now.to_f * 1000).to_i}.png")
+    raise e
   end
 
   def validate_required_configuration_is_present

--- a/test/models/scraper_test.rb
+++ b/test/models/scraper_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 class ScraperTest < Test::Unit::TestCase
 
   def test_gathers_required_values_for_scraping
-    scraper = Scraper.new(book_page_url: "https://www.amazon.com/REIGN-Tribulation-Jeffrey-McClain-Jones-ebook/dp/B00BNPFXK8/ref=sr_1_1_sspa?dchild=1&keywords=jeffrey+mcclain+jones&qid=1627886065&sr=8-1-spons&psc=1&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUExRkpXQ0lZTkhFRlhVJmVuY3J5cHRlZElkPUEwODYxMjIyMTNQSEE3TzhPRzBRNCZlbmNyeXB0ZWRBZElkPUEwMzEzODgzTTVTWTBCWkJORlYxJndpZGdldE5hbWU9c3BfYXRmJmFjdGlvbj1jbGlja1JlZGlyZWN0JmRvTm90TG9nQ2xpY2s9dHJ1ZQ==")
+    scraper = Scraper.new(book_page_url: "https://www.amazon.com/REIGN-Tribulation-Jeffrey-McClain-Jones-ebook/dp/B00BNPFXK8")
 
     assert_equal "The REIGN: Out of Tribulation", scraper.target_book_title
     assert scraper.carousel_id > 0
@@ -17,7 +17,7 @@ class ScraperTest < Test::Unit::TestCase
   end
 
   def test_successfully_finds_books_in_the_us
-    scraper = Scraper.new(book_page_url: "https://www.amazon.com/REIGN-Tribulation-Jeffrey-McClain-Jones-ebook/dp/B00BNPFXK8/ref=sr_1_1_sspa?dchild=1&keywords=jeffrey+mcclain+jones&qid=1627886065&sr=8-1-spons&psc=1&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUExRkpXQ0lZTkhFRlhVJmVuY3J5cHRlZElkPUEwODYxMjIyMTNQSEE3TzhPRzBRNCZlbmNyeXB0ZWRBZElkPUEwMzEzODgzTTVTWTBCWkJORlYxJndpZGdldE5hbWU9c3BfYXRmJmFjdGlvbj1jbGlja1JlZGlyZWN0JmRvTm90TG9nQ2xpY2s9dHJ1ZQ==")
+    scraper = Scraper.new(book_page_url: "https://www.amazon.com/REIGN-Tribulation-Jeffrey-McClain-Jones-ebook/dp/B00BNPFXK8")
     scraper.run
     assert scraper.books_found.count > 10
   end
@@ -29,7 +29,7 @@ class ScraperTest < Test::Unit::TestCase
   end
 
   def test_successfully_finds_books_in_australia
-    scraper = Scraper.new(book_page_url: "https://www.amazon.com.au/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M/ref=sr_1_2?dchild=1&keywords=seeing+jesus&qid=1627944663&sr=8-2")
+    scraper = Scraper.new(book_page_url: "https://www.amazon.com.au/Seeing-Jesus-Jeffrey-McClain-Jones-ebook/dp/B00D8KZH0M")
     scraper.run
     assert scraper.books_found.count > 10
   end


### PR DESCRIPTION
### Description:
* Simplify test URLs by removing extra params that may be causing test failures
* Capture screenshots for all dom element lookup failures
* Limit CI test runs to just the Ruby version the script uses locally